### PR TITLE
Pass `count` as keyword argument to `re.sub()`

### DIFF
--- a/filecheck/filecheck.py
+++ b/filecheck/filecheck.py
@@ -374,7 +374,7 @@ class CheckParser:
                     LINE_NUMBER_REGEX,
                     str(line_idx + offset + 1),
                     check_expression,
-                    1,
+                    count=1,
                 )
                 line_var_match = re.search(LINE_NUMBER_REGEX, check_expression)
 


### PR DESCRIPTION
This fixes two test failures under Python 3.13:

```
Failed Tests (2):
  FileCheck.py integration tests :: tests/extra_features/pseudo_numeric_variables/01_line_variable_once/test.itest
  FileCheck.py integration tests :: tests/extra_features/pseudo_numeric_variables/02_line_variable_twice/test.itest
```

Both are failing due to:

```
filecheck/filecheck.py:372: DeprecationWarning: 'count' is passed as positional argument
```

Passing `count` as positional argument to `re.sub()` has been deprecated in Python 3.13: https://docs.python.org/3.13/whatsnew/3.13.html#id9 and produces a `DeprecationWarning` exception.